### PR TITLE
안쓰는 api 삭제 

### DIFF
--- a/backend/src/controllers/calendar.ts
+++ b/backend/src/controllers/calendar.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { CalendarService } from "../services";
-import { CreateCalendarDTO, UpdateCalendarDTO } from "../interface/dto";
+import { CreateCalendarDTO } from "../interface/dto";
 import "express-async-errors";
 
 async function create(req: Request, res: Response): Promise<Response> {
@@ -17,15 +17,7 @@ async function getOne(req: Request, res: Response): Promise<Response> {
   return res.status(200).json(calendar);
 }
 
-async function update(req: Request, res: Response): Promise<Response> {
-  const calendar_id: string = req.params.calendar_id;
-  const updateCalendarDTO: UpdateCalendarDTO = req.body;
-  const calendar = await CalendarService.update(calendar_id, updateCalendarDTO);
-  return res.status(200).json(calendar);
-}
-
 export const CalendarController = {
   create,
   getOne,
-  update,
 };

--- a/backend/src/controllers/user.ts
+++ b/backend/src/controllers/user.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { UserService } from '../services';
-import { CreateUserDTO, UpdateUserDTO } from '../interface/dto';
+import { CreateUserDTO } from '../interface/dto';
 import 'express-async-errors';
 
 async function create(req: Request, res: Response): Promise<Response> {
@@ -11,25 +11,13 @@ async function create(req: Request, res: Response): Promise<Response> {
   return res.status(200).json(calendar);
 }
 
-async function update(req: Request, res: Response): Promise<Response> {
-  const calendar_id: string = req.params.calendar_id;
-  const user_id: string = req.params.user_id;
-  const updateUserDTO: UpdateUserDTO = req.body;
-  const calendar = await UserService.update(
-    calendar_id,
-    user_id,
-    updateUserDTO
-  );
-
-  return res.status(200).json(calendar);
-}
-
 async function getAll(req: Request, res: Response): Promise<Response> {
   const calendar_id: string = req.params.calendar_id;
   const users = await UserService.getAll(calendar_id);
 
   return res.status(200).json(users);
 }
+
 async function remove(req: Request, res: Response): Promise<Response> {
   const calendar_id: string = req.params.calendar_id;
   const user_id: string = req.params.user_id;
@@ -41,6 +29,5 @@ async function remove(req: Request, res: Response): Promise<Response> {
 export const UserController = {
   create,
   getAll,
-  update,
   remove,
 };

--- a/backend/src/controllers/user.ts
+++ b/backend/src/controllers/user.ts
@@ -11,13 +11,6 @@ async function create(req: Request, res: Response): Promise<Response> {
   return res.status(200).json(calendar);
 }
 
-async function getAll(req: Request, res: Response): Promise<Response> {
-  const calendar_id: string = req.params.calendar_id;
-  const users = await UserService.getAll(calendar_id);
-
-  return res.status(200).json(users);
-}
-
 async function remove(req: Request, res: Response): Promise<Response> {
   const calendar_id: string = req.params.calendar_id;
   const user_id: string = req.params.user_id;
@@ -28,6 +21,5 @@ async function remove(req: Request, res: Response): Promise<Response> {
 
 export const UserController = {
   create,
-  getAll,
   remove,
 };

--- a/backend/src/db/model.ts
+++ b/backend/src/db/model.ts
@@ -1,17 +1,11 @@
 import { Schema, model } from "mongoose";
-import { Calendar, CalendarType, ScheduleValidType } from "../interface/entity";
+import { Calendar, ScheduleValidType } from "../interface/entity";
 
 const schema = new Schema<Calendar>(
   {
     name: {
       type: String,
       required: true,
-    },
-    type: {
-      type: String,
-      required: true,
-      enum: CalendarType,
-      default: CalendarType.MONTHLY,
     },
     start: { type: String, required: false },
     end: { type: String, required: false },

--- a/backend/src/interface/dto.ts
+++ b/backend/src/interface/dto.ts
@@ -1,4 +1,4 @@
-import { Schedule } from './entity';
+import { Schedule } from "./entity";
 
 export class CreateCalendarDTO {
   name!: string;
@@ -9,6 +9,7 @@ export class CreateCalendarDTO {
 export class CreateUserDTO {
   name!: string;
   color!: string;
+  schedules: Schedule[] = [];
 }
 
 export class UpdateSchduleDTO {

--- a/backend/src/interface/dto.ts
+++ b/backend/src/interface/dto.ts
@@ -1,15 +1,7 @@
-import { CalendarType, Schedule } from "./entity";
+import { Schedule } from './entity';
 
 export class CreateCalendarDTO {
-  type!: CalendarType;
   name!: string;
-  start?: string;
-  end?: string;
-}
-
-export class UpdateCalendarDTO {
-  type?: CalendarType;
-  name?: string;
   start?: string;
   end?: string;
 }
@@ -17,11 +9,6 @@ export class UpdateCalendarDTO {
 export class CreateUserDTO {
   name!: string;
   color!: string;
-}
-
-export class UpdateUserDTO {
-  name?: string;
-  color?: string;
 }
 
 export class UpdateSchduleDTO {

--- a/backend/src/interface/entity.ts
+++ b/backend/src/interface/entity.ts
@@ -16,15 +16,9 @@ export interface User {
   schedules: Schedule[];
 }
 
-export enum CalendarType {
-  MONTHLY = "MONTHLY",
-  WEEKLY = "WEEKLY",
-}
-
 export interface Calendar {
   _id?: string;
   name: string;
-  type: CalendarType;
   start?: string;
   end?: string;
   users: User[];

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -14,7 +14,6 @@ router.get('/:calendar_id', CalendarController.getOne);
 
 // 🙍‍♂️ 유저 라우터
 router.post('/:calendar_id/users', UserController.create);
-router.get('/:calendar_id/users', UserController.getAll);
 router.delete('/:calendar_id/users/:user_id', UserController.remove);
 
 // 🎏 스케쥴 라우터

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -11,11 +11,9 @@ const router: Router = Router();
 // 📆 캘린더 라우터
 router.post('/', CalendarController.create);
 router.get('/:calendar_id', CalendarController.getOne);
-router.put('/:calendar_id', CalendarController.update);
 
 // 🙍‍♂️ 유저 라우터
 router.post('/:calendar_id/users', UserController.create);
-router.put('/:calendar_id/users', UserController.update);
 router.get('/:calendar_id/users', UserController.getAll);
 router.delete('/:calendar_id/users/:user_id', UserController.remove);
 

--- a/backend/src/services/calendar.ts
+++ b/backend/src/services/calendar.ts
@@ -1,4 +1,4 @@
-import { CreateCalendarDTO, UpdateCalendarDTO } from "../interface/dto";
+import { CreateCalendarDTO } from "../interface/dto";
 import CalendarModel from "../db/model";
 import ApiError from "../modules/error";
 import { Calendar } from "../interface/entity";
@@ -22,19 +22,8 @@ async function getOne(calendar_id: string): Promise<Calendar> {
   return getOneDocument(calendar_id);
 }
 
-async function update(
-  calendar_id: string,
-  updateCalendarDTO: UpdateCalendarDTO
-): Promise<Calendar> {
-  const calendar = await getOneDocument(calendar_id);
-  return calendar.update({
-    ...updateCalendarDTO,
-  });
-}
-
 export const CalendarService = {
   create,
   getOne,
   getOneDocument,
-  update,
 };

--- a/backend/src/services/schedule.ts
+++ b/backend/src/services/schedule.ts
@@ -1,5 +1,4 @@
 import { UpdateSchduleDTO } from '../interface/dto';
-import ApiError from '../modules/error';
 import { Calendar } from '../interface/entity';
 import { CalendarService } from './calendar';
 import { UserService } from '.';

--- a/backend/src/services/schedule.ts
+++ b/backend/src/services/schedule.ts
@@ -9,7 +9,7 @@ async function update(
   updateSchduleDTO: UpdateSchduleDTO
 ): Promise<Calendar> {
   const calendar = await CalendarService.getOneDocument(calendar_id);
-  const index = UserService.getIndexOrFail(calendar, user_id);
+  const index = UserService.findIndexOrFail(calendar, user_id);
   const user = calendar.users[index];
   user.schedules = updateSchduleDTO.schedules;
 

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -19,12 +19,6 @@ async function create(
   return calendar.users[calendar.users.length - 1];
 }
 
-async function getAll(calendar_id: string): Promise<User[]> {
-  const calendar = await CalendarService.getOne(calendar_id);
-
-  return calendar.users;
-}
-
 function getIndexOrFail(
   calendar: Calendar & Document,
   user_id: string
@@ -50,7 +44,6 @@ async function remove(calendar_id: string, user_id: string): Promise<Calendar> {
 
 export const UserService = {
   create,
-  getAll,
   getIndexOrFail,
   remove,
 };

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -16,7 +16,7 @@ async function create(
   return calendar.users[calendar.users.length - 1];
 }
 
-function getIndexOrFail(
+function findIndexOrFail(
   calendar: Calendar & Document,
   user_id: string
 ): number {
@@ -32,7 +32,7 @@ function getIndexOrFail(
 
 async function remove(calendar_id: string, user_id: string): Promise<Calendar> {
   const calendar = await CalendarService.getOneDocument(calendar_id);
-  const user_index = getIndexOrFail(calendar, user_id);
+  const user_index = findIndexOrFail(calendar, user_id);
 
   calendar.users = calendar.users.filter((_, index) => index !== user_index);
 
@@ -41,6 +41,6 @@ async function remove(calendar_id: string, user_id: string): Promise<Calendar> {
 
 export const UserService = {
   create,
-  getIndexOrFail,
+  findIndexOrFail,
   remove,
 };

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -9,13 +9,10 @@ async function create(
   createUserDTO: CreateUserDTO
 ): Promise<User> {
   const calendar = await CalendarService.getOneDocument(calendar_id);
-  const user: User = {
-    schedules: [],
-    ...createUserDTO,
-  };
 
-  calendar.users.push(user);
+  calendar.users.push(createUserDTO);
   await calendar.save();
+
   return calendar.users[calendar.users.length - 1];
 }
 

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -1,4 +1,4 @@
-import { CreateUserDTO, UpdateUserDTO } from '../interface/dto';
+import { CreateUserDTO } from '../interface/dto';
 import ApiError from '../modules/error';
 import { Calendar, User } from '../interface/entity';
 import { Document } from 'mongoose';
@@ -20,9 +20,9 @@ async function create(
 }
 
 async function getAll(calendar_id: string): Promise<User[]> {
-  return await CalendarService.getOne(calendar_id).then(
-    (calendar) => calendar.users
-  );
+  const calendar = await CalendarService.getOne(calendar_id);
+
+  return calendar.users;
 }
 
 function getIndexOrFail(
@@ -39,26 +39,9 @@ function getIndexOrFail(
   return index;
 }
 
-async function update(
-  calendar_id: string,
-  user_id: string,
-  updateUserDTO: UpdateUserDTO
-): Promise<Calendar> {
-  const calendar = await CalendarService.getOneDocument(calendar_id);
-  const index = getIndexOrFail(calendar, user_id);
-  const user = calendar.users[index];
-  calendar.users[index] = {
-    ...user,
-    ...updateUserDTO,
-  };
-
-  return calendar.save();
-}
-
 async function remove(calendar_id: string, user_id: string): Promise<Calendar> {
   const calendar = await CalendarService.getOneDocument(calendar_id);
   const user_index = getIndexOrFail(calendar, user_id);
-  console.log('hi : ', user_index);
 
   calendar.users = calendar.users.filter((_, index) => index !== user_index);
 
@@ -69,6 +52,5 @@ export const UserService = {
   create,
   getAll,
   getIndexOrFail,
-  update,
   remove,
 };

--- a/frontend/src/Network/UserService.ts
+++ b/frontend/src/Network/UserService.ts
@@ -19,23 +19,6 @@ export const UserService = {
     }
     return response.data;
   },
-  updateUser: async (calendar_id) => {
-    const method = 'POST';
-    const url = API.url(`${calendar_id}/users`);
-    // const body = user;
-
-    let response;
-    try {
-      response = await API.AXIOS({
-        method,
-        // data: body,
-        url,
-      });
-    } catch (error) {
-      console.log(error);
-    }
-    return response.data;
-  },
   deleteUser: async (calendar_id, user_id) => {
     const method = 'DELETE';
     const url = API.url(`${calendar_id}/users/${user_id}`);


### PR DESCRIPTION
사용하고 있지 않은 API들을 삭제했습니다.

삭제한 API목록은 다음과 같습니다.
- 유저 수정 api
- 캘린더 수정 api
- 유저 정보 가져오기 api (캘린더 정보 가져오기 api 와 중복됨)

그 외에 월별 캘린더와 주별 캘린더로 나누려고 했던 기존 기획이, 앞으로 월별 캘린더만 하는것으로 변경됨에 따라
캘린더 스키마에서 type field 을 삭제하였습니다.